### PR TITLE
delay the href click redirect

### DIFF
--- a/kano-notifications.html
+++ b/kano-notifications.html
@@ -153,10 +153,16 @@
             return read ? 'read' : 'unread';
         },
         _onNotificationTap (e) {
+            e.preventDefault(); 
             var notification = e.model.get('notification'),
-                index = e.model.get('index');
+                index = e.model.get('index'),
+                link = this._computeNotificationUrl(notification);
+
             this.fire('notifications-read', notification);
             this.set(`notifications.${index}.read`, true);
+            setTimeout(function(){
+                window.location.href = link;
+            },0);
         },
         _computeNotificationUrl (notification) {
             var path = '/notifications';


### PR DESCRIPTION
Sometimes notification api didn't call because href link redirect the page first, cause the api call missed